### PR TITLE
Fix mobile reload loader doesn't hide bug

### DIFF
--- a/css/intro.css
+++ b/css/intro.css
@@ -1,7 +1,6 @@
 /*  -------------------------------------------------- Intro ------------------------------------------------------  */
 .intro--wrapper {
     position: relative;
-    overflow-x: hidden !important;
     background-color: var(--bgcolor-primary);
     min-height: 100vh !important;
     height: fit-content !important;

--- a/index.html
+++ b/index.html
@@ -175,10 +175,7 @@
 <script src="./js/contact.js"></script>
 <script src="./js/about.js"></script>
 <script src="./js/download.js"></script>
-<script
-    defer
-    src="./js/app.js"
-></script>
+<script src="./js/app.js"></script>
 <!-- Google tag (gtag.js) -->
 <script
     async
@@ -1935,5 +1932,5 @@
         </footer>
     </div>
 </body>
-
+<script defer src="./js/load.js"></script>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -324,7 +324,6 @@ $(function () {
         }
     });
     /* =============== Window Event Binding ============== */
-    $(window).on('hashchange', router);
     $(window).on('beforeunload', function () {
         sessionStorage.setItem(PAGE_RELOADED_STORAGE_KEY, 'reloaded');
         INITIALIZED = false;

--- a/js/app.js
+++ b/js/app.js
@@ -323,15 +323,13 @@ $(function () {
             $('#mobile-nav-icon').removeClass('open');
         }
     });
-
-    $(window).on('load', router);
+    /* =============== Window Event Binding ============== */
     $(window).on('hashchange', router);
     $(window).on('beforeunload', function () {
         sessionStorage.setItem(PAGE_RELOADED_STORAGE_KEY, 'reloaded');
         INITIALIZED = false;
     });
     $(window).on('resize', onWindowResize);
-
 });
 
 /**
@@ -552,13 +550,6 @@ function toggleTheme() {
     }
 }
 
-function onBodyLoaded() {
-    isLoading = true;
-    if (IS_RELOADED) {
-        hideLoader();
-    }
-}
-
 function setLightTheme(page) {
     switch (page) {
         case 'intro':
@@ -624,3 +615,4 @@ function showArrow(element) {
 function hideArrow(timeline) {
     timeline.reverse();
 }
+

--- a/js/load.js
+++ b/js/load.js
@@ -9,3 +9,4 @@ function load() {
 }
 
 $(window).on('load', load);
+$(window).on('hashchange', load);

--- a/js/load.js
+++ b/js/load.js
@@ -1,0 +1,11 @@
+
+function load() {
+    router();
+    if (IS_RELOADED) {
+        hideLoader();
+        sessionStorage.setItem(PAGE_RELOADED_STORAGE_KEY, null);
+        console.log('Page reloaded');
+    }
+}
+
+$(window).on('load', load);


### PR DESCRIPTION
This fixes a bug were the loader doesn't get hidden after window is reloaded on mobile browser.